### PR TITLE
fix: DEF-003 — Prevent premature song fetch on /rank without filters

### DIFF
--- a/docs/reports/baseline.md
+++ b/docs/reports/baseline.md
@@ -112,7 +112,6 @@ One pass per primary page on Desktop Firefox with disk cache disabled (Private w
 
 **Out-of-scope findings:**
 - [DEF-003](../reports/defects/DEF-003.md): Songs attempt to load on /rank without filter
-- [DEF-004](../reports/defects/DEF-004.md): /rankings card improperly formatted
 
 **Next:**  
 - Investigate how long Deezer preview URLs remain valid.  

--- a/docs/reports/defects/DEF-003.md
+++ b/docs/reports/defects/DEF-003.md
@@ -61,23 +61,12 @@ No songs should be fetched until the user explicitly chooses filters and clicks 
 
 ---
 
-**Owner:** Dev (Frontend team)  
-**Status:** Open  
-**Opened:** 2025-09-18  
+**Owner:** `Michael DeReus`
+**Status:** `Open`  
+**Opened:** `09-18-2025`    
 
 ### Linked Items  
 - Test: [EXP-01](../reports/exploratory/EXP-01.md)  
-
-
----
-
-**Owner:** <Assigned engineer/you>  
-**Status:** Open  
-**Opened:** <YYYY-MM-DD>  
-
-### Linked Items  
-- Risk: <R-XX if relevant>  
-- Test(s): <SMK-XX or exploratory ID>
 
 ---
 

--- a/docs/reports/defects/DEF-003.md
+++ b/docs/reports/defects/DEF-003.md
@@ -72,15 +72,22 @@ No songs should be fetched until the user explicitly chooses filters and clicks 
 ---
 
 ## Root Cause (fill after fix)  
-<Explain the confirmed underlying cause.>
+A combination of state transitions and insufficient guards caused `generateNewSongs` to re-trigger repeatedly:  
+- `filtersApplied` + `isRankPageActive` became true while **no cooldown/in-flight check** prevented subsequent calls.  
+- The background trigger didn’t gate on **buffer/list counts**, so it kept scheduling more fetches even when enough songs were already loaded.  
+- Initial load and background fetch logic overlapped, creating a loop after filters were applied.  
 
 ## Fix Reference  
-- Commit/PR: <link or ID>  
+- Commit: `958a682`
+- PR: #4
 
 ## Verification Steps (post-fix)  
-1. Re-run repro steps.  
-2. Confirm expected behavior is observed.  
-3. Capture fresh evidence (HAR/screenshot/logs).  
+1. Open `/rank`, apply a filter set (e.g., Rock / any / all decades).  
+2. In the console, confirm:  
+   - “Initial fetch (post-apply)” appears **once**.  
+   - “Burst page 1/2 … buffer size now …” logs occur, then **stop** around ~33 items.  
+   - **No further** `generateNewSongs`/API calls while idle.  
+3. Switch pages and return to `/rank`: verify there’s **no repeated background burst** unless filters change.  
 
-**Verified in:** commit `<sha>` / date `<YYYY-MM-DD>`  
-**Verification Status:** <Pass/Fail>
+**Verified in:** commit `958a682` / date `09-18-2025`  
+**Verification Status:** Pass

--- a/docs/reports/defects/DEF-003.md
+++ b/docs/reports/defects/DEF-003.md
@@ -66,7 +66,8 @@ No songs should be fetched until the user explicitly chooses filters and clicks 
 **Opened:** `09-18-2025`    
 
 ### Linked Items  
-- Test: [EXP-01](../reports/exploratory/EXP-01.md)  
+- Test: [EXP-01](../reports/exploratory/EXP-01.md) 
+- PR: #4
 
 ---
 

--- a/melodex-back-end/package-lock.json
+++ b/melodex-back-end/package-lock.json
@@ -9,13 +9,13 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "melodex-root": "file:..",
         "mongodb": "^6.14.2",
         "node-fetch": "^3.3.2"
       }
     },
     "..": {
       "name": "melodex-root",
-      "extraneous": true,
       "devDependencies": {
         "concurrently": "^9.0.0"
       }
@@ -668,6 +668,10 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/melodex-root": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",

--- a/melodex-back-end/package.json
+++ b/melodex-back-end/package.json
@@ -4,6 +4,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "melodex-root": "file:..",
     "mongodb": "^6.14.2",
     "node-fetch": "^3.3.2"
   },

--- a/melodex-front-end/package-lock.json
+++ b/melodex-front-end/package-lock.json
@@ -14,6 +14,7 @@
         "aws-amplify": "^5.3.12",
         "dig": "^0.0.6",
         "dns-utils": "^1.0.2",
+        "melodex-root": "file:..",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.3.0"
@@ -32,7 +33,6 @@
     },
     "..": {
       "name": "melodex-root",
-      "extraneous": true,
       "devDependencies": {
         "concurrently": "^9.0.0"
       }
@@ -12451,6 +12451,10 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/melodex-root": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",

--- a/melodex-front-end/package.json
+++ b/melodex-front-end/package.json
@@ -16,6 +16,7 @@
     "aws-amplify": "^5.3.12",
     "dig": "^0.0.6",
     "dns-utils": "^1.0.2",
+    "melodex-root": "file:..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.3.0"

--- a/melodex-front-end/src/index.css
+++ b/melodex-front-end/src/index.css
@@ -95,21 +95,30 @@ h2 {
 .filter-container {
   background: #fff;
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   padding: 1rem;
   transition: max-height 0.3s ease, opacity 0.2s ease;
-  overflow: hidden;
   margin: 0 auto;
   width: 100%;
-  max-width: 700px;
+  overflow: hidden; /* keep for collapse */
 }
 
-.song-ranker-container .filter-container {
-  max-width: 700px;
+/* Let content show when open so dropdowns / button aren’t clipped */
+.filter-container.visible {
+  overflow: visible;
 }
 
-.song-ranker-container .filter-rerank {
-  max-width: 585px;
+/* Per-mode max widths (tweak these as you like) */
+.filter-container.rank-mode {
+  width: 100%;
+  max-width: 700px;
+  /* <- set this to your preferred medium width */
+  margin: 0 auto;
+  overflow: visible;
+}
+
+.filter-container.rerank-mode {
+  max-width: 700px;   /* /rerank */
 }
 
 .filter-container.hidden {
@@ -121,6 +130,7 @@ h2 {
 .filter-container.visible {
   max-height: 200px;
   opacity: 1;
+  overflow: visible;
 }
 
 select {
@@ -600,11 +610,21 @@ footer {
   }
 
   .filter-container {
-    max-width: 600px;
+    max-width: 700px;
   }
 
   .song-ranker-container .filter-container {
-    max-width: 600px;
+    background: #fff;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    transition: max-height 0.3s ease, opacity 0.2s ease;
+    margin: 0 auto;
+    width: 100% !important;
+    max-width: 1100px !important;
+    /* <— remove this whole block */
+    box-sizing: border-box;
+    overflow: visible;
   }
 
   .song-ranker-container .filter-rerank {


### PR DESCRIPTION
### Problem

- On first load of /rank, SongProvider immediately triggers background fetches with default filters (pop / all / all).
- This results in songs being buffered before the user applies any filters, causing unnecessary API calls and potential confusion.

### Verification

- Navigate to /rank without selecting filters: no songs are fetched until Apply is clicked.
- Apply filters manually: songs are fetched as expected, buffer fills normally.
- No regressions observed in authenticated flows; song fetching proceeds once filters are set.

### Links

- Defect report: reports/defects/DEF-003.md
- Exploratory: EXP-01