### PR TITLE
US-01 AC-01.3–AC-01.5: Cancel handling, secure storage, single-refresh on 401

### DIFF
--- a/docs/test/test-plan.md
+++ b/docs/test/test-plan.md
@@ -145,18 +145,19 @@ Plan and execute testing for the Spotify Playlist Export feature and a thin guar
 ---
 
 ## 9. Schedule & Milestones (high level)
-Week 1–2
-- Finalize Acceptance Criteria, draft/commit tests skeletons, set up CI secrets
-Week 3–5
-- Implement + TDD export backend, modal, progress, confirmation
-Week 6
-- Thin regression guards; Cypress E2E edges; revoke access
-Week 7
-- Non-functional sanity; flake fixes
-Week 8–9
-- Stabilization, documentation (reports, videos)
-Week 10
-- Portfolio packaging, final sign-off
+
+- Week 1–2  
+    - Finalize Acceptance Criteria, draft/commit tests skeletons, set up CI secrets  
+- Week 3–5  
+    - Implement + TDD export backend, modal, progress, confirmation  
+- Week 6-7  
+    - Thin regression guards; Cypress E2E edges; revoke access  
+- Week 8  
+    - Non-functional sanity; flake fixes  
+- Week 9  
+    - Stabilization, documentation (reports, videos)  
+- Week 10  
+    - Portfolio packaging, final sign-off  
 
 ---
 

--- a/docs/test/traceability.md
+++ b/docs/test/traceability.md
@@ -15,150 +15,153 @@
 ## Matrix
 > *This matrix maps User Stories (US) → Acceptance Criteria (AC) → Test Cases (Unit / Integration / E2E), and links Smokes, Defects, and Risks.*  
 
+## Traceability Matrix — Spotify Playlist Export
+
 <div class="trace-table" markdown="1">
-| Story ID | User Story (short) | Acceptance Criteria | Unit Tests | UI Tests | Integration Tests | E2E Tests | Smokes | Defects | Risks | Status |
+| Story ID | User Story | Acceptance Criteria | Unit Tests | UI Tests | Integration Tests | E2E Tests | Smokes | Defects | Risks | Status |
 |---|---|---|---|---|---|---|---|---|---|---|
-| **US-01** | Authenticate with Spotify | **AC-01.1** Redirect back with valid session<br>**AC-01.2** Prompt login if unauthenticated protected action<br>**AC-01.3** No tokens stored on cancel<br>**AC-01.4** Tokens stored securely<br>**AC-01.5** Token refresh works | **UT-001-Auth** Cookie flags httpOnly SameSite Secure max-age<br>**UT-002-Auth** Revoke clears tokens<br>**UT-008-Auth** Refresh on 401 | **UI-001-AuthGuard** Export CTA prompts connect when unauthenticated | **IT-001-Auth** Callback success sets cookies plus 302<br>**IT-002-Auth** Auth session connected flag<br>**IT-010-Auth** Revoke blocks export | **E2E-001-Export** Happy path including auth<br>**E2E-003-Auth** Cancel flow leaves no tokens | **SMK-00** Login basics<br>**SMK-01** Protected action | **DEF-001** | **R-01** OAuth config<br>**R-02** Token refresh | <span class="pill progress">In Progress</span> |
-| **US-02** | Export ranked songs by current filter | **AC-02.1** Creates playlist with filtered songs<br>**AC-02.2** Empty filter shows no songs to export<br>**AC-02.3** Spotify track mapping applied<br>**AC-02.4** Only ranked and unskipped included | **UT-003-Export** Filter builder<br>**UT-004-Export** Deezer to Spotify mapping<br>**UT-011-Export** Selector rules | **UI-009-ExportModal** Renders zero items confirm disabled | **IT-003-Export** Creates playlist with only filtered<br>**IT-004-Export** Empty filter message<br>**IT-012-Ranked** Ranked contract deps | **E2E-001-Export** Happy path<br>**E2E-002-Export** Empty filter path | **SMK-09** Export data persistence | – | **R-04** Mapping quality<br>**R-14** Ranking integrity | <span class="pill planned">Planned</span> |
-| **US-03** | Review and remove before export | **AC-03.1** Remove before export<br>**AC-03.2** Only remaining songs exported<br>**AC-03.3** Count and summary updates | **UI-002-ExportModal** Remove updates list<br>**UI-003-ExportModal** Count and summary updates | **UI-002-ExportModal** Remove updates list<br>**UI-003-ExportModal** Count and summary updates | **IT-005-Export** Respects removals | **E2E-001-Export** Happy path | **SMK-09** Export data persistence | – | **R-15** Duplicates<br>**R-20** Export scope clarity | <span class="pill planned">Planned</span> |
-| **US-04** | Add playlist name and description | **AC-04.1** Name and description applied<br>**AC-04.2** Default name format | **UT-006-Export** Name and description in payload | **UI-004-ExportModal** Default name formatting editable | **IT-006-Export** Name and description in Spotify payload | **E2E-001-Export** Happy path | **SMK-09** Export data persistence | – | **R-10** Perception and progress<br>**R-20** Scope clarity | <span class="pill planned">Planned</span> |
-| **US-05** | Real-time feedback during export | **AC-05.1** Progress shown<br>**AC-05.2** Success state<br>**AC-05.3** Error state | – | **UI-005-Progress** Idle to loading to success or error | **IT-007-Errors** Backend failure returns error contract | **E2E-004-Errors** Progress shows error<br>**E2E-001-Export** Happy path | **SMK-09** Export data persistence | – | **R-10** Perception and progress | <span class="pill planned">Planned</span> |
-| **US-06** | Error handling | **AC-06.1** Per-song errors surfaced<br>**AC-06.2** 429 shows try again later<br>**AC-06.3** Retry or skip available | **UT-005-Export** 429 backoff policy<br>**UT-007-Export** Per-item error surfacing | **UI-006-Errors** List plus skip or retry actions | **IT-008-Export** Inject 429 with retry guidance<br>**IT-011-Errors** Per-track 404 list | **E2E-005-RateLimit** 429 path<br>**E2E-009-Errors** Partial failures | **SMK-09** Export data persistence | – | **R-03** 429 rate limit<br>**R-11** Partial failures UX | <span class="pill planned">Planned</span> |
-| **US-07** | Confirmation with playlist link | **AC-07.1** Confirmation link present<br>**AC-07.2** Deep link with fallback | – | **UI-007-Confirm** Link present and correct<br>**UI-008-DeepLink** App deep link and web fallback | **IT-009-Confirm** Response includes playlist URL | **E2E-001-Export** Happy path<br>**E2E-006-DeepLink** App versus web fallback | **SMK-09** Export data persistence | – | **R-09** Mobile deep link<br>**R-10** Perception | <span class="pill planned">Planned</span> |
-| **US-08** | Revoke Spotify access | **AC-08.1** Disconnect invalidates tokens<br>**AC-08.2** Export prompts reconnect<br>**AC-08.3** Removed from Spotify connected apps | **UT-002-Auth** Revoke clears tokens | – | **IT-010-Auth** Revoke requires reconnect to export | **E2E-007-Revoke** Blocked until reconnect | **SMK-00** Auth basics | – | **R-02** Token refresh and session | <span class="pill planned">Planned</span> |
-| **Baseline** | Ranking flows and filters | **AC-F.1** No auto-fetch until Apply<br>**AC-F.2** Background burst capped about 33<br>**AC-F.3** Filters do not clip UI | **UT-012-Ranking** ELO math sanity | – | – | – | **SMK-02** Filter and nav<br>**SMK-03** Filter and nav<br>**SMK-08** Filter and nav | **DEF-003** | **R-21** Unbounded fetch costs | <span class="pill pass">Passed</span> |
-| **Baseline** | Rankings playback stability | **AC-P.1** Older previews refresh<br>**AC-P.2** No broken players | – | – | **IT-012-Ranked** Ranked endpoint contract | – | **SMK-06** Preview robustness<br>**SMK-07** Preview robustness | **DEF-002** | **R-05** Preview expiry | <span class="pill pass">Passed</span> |
+| **US-01** | Authenticate with Spotify | AC-01.1 <br>AC-01.2 <br>AC-01.3 <br>AC-01.4 <br>AC-01.5 | UT-001-Auth<br>UT-002-Auth<br>UT-008-Auth | UI-001-AuthGuard | IT-001-Auth<br>IT-002-Auth<br>IT-010-Auth | E2E-001-Export<br>E2E-003-Auth | SMK-00<br>SMK-01 | DEF-001 | R-01<br>R-02 | <span class="pill progress">In Progress</span> |
+| **US-02** | Export ranked songs by current filter | AC-02.1 <br>AC-02.2 <br>AC-02.3 <br>AC-02.4 | UT-003-Export<br>UT-004-Export<br>UT-011-Export | UI-009-ExportModal | IT-003-Export<br>IT-004-Export<br>IT-012-Ranked | E2E-001-Export<br>E2E-002-Export | SMK-09 | – | R-04<br>R-14 | <span class="pill planned">Planned</span> |
+| **US-03** | Review and remove before export | AC-03.1<br>AC-03.2 <br>AC-03.3 | UI-002-ExportModal<br>UI-003-ExportModal | UI-002-ExportModal<br>UI-003-ExportModal | IT-005-Export | E2E-001-Export | SMK-09 | – | R-15<br>R-20 | <span class="pill planned">Planned</span> |
+| **US-04** | Add playlist name and description | AC-04.1 <br>AC-04.2 | UT-006-Export | UI-004-ExportModal | IT-006-Export | E2E-001-Export | SMK-09 | – | R-10<br>R-20 | <span class="pill planned">Planned</span> |
+| **US-05** | Real-time feedback during export | AC-05.1 <br>AC-05.2 <br>AC-05.3 | – | UI-005-Progress | IT-007-Errors | E2E-004-Errors<br>E2E-001-Export | SMK-09 | – | R-10 | <span class="pill planned">Planned</span> |
+| **US-06** | Error handling | AC-06.1 <br>AC-06.2 <br>AC-06.3 | UT-005-Export<br>UT-007-Export | UI-006-Errors | IT-008-Export<br>IT-011-Errors | E2E-005-RateLimit<br>E2E-009-Errors | SMK-09 | – | R-03<br>R-11 | <span class="pill planned">Planned</span> |
+| **US-07** | Confirmation with playlist link | AC-07.1 <br>AC-07.2 | – | UI-007-Confirm<br>UI-008-DeepLink | IT-009-Confirm | E2E-001-Export<br>E2E-006-DeepLink | SMK-09 | – | R-09<br>R-10 | <span class="pill planned">Planned</span> |
+| **US-08** | Revoke Spotify access | AC-08.1 <br>AC-08.2 <br>AC-08.3 | UT-002-Auth | – | IT-010-Auth | E2E-007-Revoke | SMK-00 | – | R-02 | <span class="pill planned">Planned</span> |
+| **Baseline** | Ranking flows and filters | AC-F.1 <br>AC-F.2<br>AC-F.3 | UT-012-Ranking | – | – | – | SMK-02<br>SMK-03<br>SMK-08 | DEF-003 | R-21 | <span class="pill pass">Passed</span> |
+| **Baseline** | Rankings playback stability | AC-P.1 <br>AC-P.2 | – | – | IT-012-Ranked | – | SMK-06<br>SMK-07 | DEF-002 | R-05 | <span class="pill pass">Passed</span> |
 
 </div>
 
 ---
 
-## Acceptance Criteria + Test Inventory Reference
-> *For full inventory with descriptors see test plan.*
+## Acceptance Criteria + Test Case Inventory Reference
+> *For full inventory with descriptors see [test plan](/test-plan/#12. Test Cases Inventory).*
 
 ### Feature Testing
 
 - **US-01 — Authenticate with Spotify**
-    - **AC-01.1** — Given I complete Spotify OAuth successfully, when Melodex receives the callback with a valid code and state/PKCE, then Melodex establishes a valid session (secure httpOnly, SameSite cookies) and redirects to the post-login route (e.g., `/rank`).
-        - UT-001-Auth  
-        - IT-001-Auth  
-    - **AC-01.2** — Given I am not authenticated, when I navigate to a protected route or attempt an export, then I am prompted to log in to Spotify first.
-        - UI-001-AuthGuard  
-        - IT-002-Auth  
-        - IT-010-Auth  
-        - E2E-003-Auth  
-    - **AC-01.3** — Given I cancel at Spotify (callback contains `error=access_denied`), when Melodex handles the callback, then no access/refresh tokens are stored anywhere and I remain unauthenticated.
-        - IT-001-Auth  
-    - **AC-01.4** — Given a successful token exchange, when the app stores credentials, then access/refresh tokens are stored only in secure, httpOnly, SameSite cookies and never in web storage.
-        - UT-001-Auth  
-        - IT-001-Auth  
-    - **AC-01.5** — Given my access token expires, when a protected request returns 401, then the app attempts a single refresh and retries once on success or logs me out and prompts reconnect on failure.
-        - UT-008-Auth  
-        - IT-010-Auth  
+    - **AC-01.1** Redirect back with valid session  
+        - UT-001-Auth — Cookie flags httpOnly SameSite Secure max-age  
+        - IT-001-Auth — Callback success sets cookies plus 302  
+    - **AC-01.2** Prompt login if unauthenticated protected action  
+        - UI-001-AuthGuard — Export CTA prompts connect when unauthenticated  
+        - IT-002-Auth — Auth session connected flag  
+        - IT-010-Auth — Revoke blocks export  
+        - E2E-003-Auth — Unauth prompt; no export call  
+    - **AC-01.3** No tokens stored on cancel  
+        - *(Pending)* IT-001d — Callback with error=access_denied → no cookies, redirect to login  
+    - **AC-01.4** Tokens stored securely  
+        - UT-001-Auth — Cookie flags httpOnly SameSite Secure max-age  
+        - IT-001-Auth — Callback success sets cookies plus 302  
+    - **AC-01.5** Token refresh works  
+        - UT-008-Auth — Refresh on 401  
+        - IT-010-Auth — Revoke requires reconnect to export  
 
 - **US-02 — Export ranked songs by current filter**
-    - **AC-02.1** — Given I have ranked songs and an active filter, when I select “Export to Spotify,” then a new Spotify playlist is created containing only the songs that match the current filter.
-        - UT-003-Export  
-        - UT-004-Export  
-        - IT-003-Export  
-        - IT-004-Export  
-        - E2E-001-Export  
-    - **AC-02.2** — Given the current filter matches no songs, when I attempt export, then I see a “No songs available for export” message and no playlist is created.
-        - IT-004-Export  
-        - E2E-002-Export  
-    - **AC-02.3** — Given Melodex holds Deezer-backed metadata for my ranked list, when songs are exported to Spotify, then each exported track resolves to the correct Spotify track using the mapping rules and unmapped tracks follow error handling.
-        - UT-004-Export  
-        - UT-011-Export  
-        - IT-004-Export  
-        - IT-012-Ranked  
-    - **AC-02.4** — Given I removed or skipped some items in the review step, when I export, then only ranked and not-removed items are sent to Spotify.
-        - UT-009-Export  
-        - IT-005-Export  
-        - IT-006-Export  
+    - **AC-02.1** Creates playlist with filtered songs  
+        - UT-003-Export — Filter builder  
+        - UT-004-Export — Deezer to Spotify mapping  
+        - IT-003-Export — Creates playlist with only filtered  
+        - IT-004-Export — Empty filter message  
+        - E2E-001-Export — Happy path including auth  
+    - **AC-02.2** Empty filter shows no songs to export  
+        - IT-004-Export — Empty filter message  
+        - E2E-002-Export — Empty filter path  
+    - **AC-02.3** Spotify track mapping applied  
+        - UT-004-Export — Deezer to Spotify mapping  
+        - UT-011-Export — Selector rules  
+        - IT-004-Export — Empty filter message  
+        - IT-012-Ranked — Ranked contract deps  
+    - **AC-02.4** Only ranked and unskipped included  
+        - UT-009-Export — Selector rules  
+        - IT-005-Export — Respects removals  
+        - IT-006-Export — Name and description in Spotify payload  
 
-- **US-03 — Review & remove before export**
-    - **AC-03.1** — Given I click “Export to Spotify,” when the export modal opens, then I can see the list of songs to be exported including song title and artist.
-        - UI-002-ExportModal  
-        - IT-005-Export  
-    - **AC-03.2** — Given I remove one or more songs in the modal, when I proceed with export, then only the remaining songs are included in the playlist.
-        - UI-003-ExportModal  
-        - IT-005-Export  
-    - **AC-03.3** — Given I change filters or close the modal, when I reopen the modal, then the list reflects the latest filter and prior removals are reset unless I explicitly saved changes, and counts/summary update accordingly.
-        - UI-003-ExportModal  
-        - IT-005-Export  
+- **US-03 — Review and remove before export**
+    - **AC-03.1** Remove before export  
+        - UI-002-ExportModal — Remove updates list  
+        - IT-005-Export — Respects removals  
+    - **AC-03.2** Only remaining songs exported  
+        - UI-003-ExportModal — Count and summary updates  
+        - IT-005-Export — Respects removals  
+    - **AC-03.3** Count and summary updates  
+        - UI-003-ExportModal — Count and summary updates  
+        - IT-005-Export — Respects removals  
 
-- **US-04 — Add playlist name/description**
-    - **AC-04.1** — Given I am exporting a playlist, when I enter a name and/or description, then the created Spotify playlist uses those values.
-        - UT-006-Export  
-        - UI-004-ExportModal  
-        - IT-006-Export  
-    - **AC-04.2** — Given I do not enter a name, when I confirm export, then the playlist name defaults to “Melodex Playlist YYYY-MM-DD.”
-        - UT-006-Export  
-        - UI-004-ExportModal  
-        - IT-006-Export  
+- **US-04 — Add playlist name and description**
+    - **AC-04.1** Name and description applied  
+        - UT-006-Export — Name and description in payload  
+        - UI-004-ExportModal — Default name formatting editable  
+        - IT-006-Export — Name and description in Spotify payload  
+    - **AC-04.2** Default name format  
+        - UT-006-Export — Name and description in payload  
+        - UI-004-ExportModal — Default name formatting editable  
+        - IT-006-Export — Name and description in Spotify payload  
 
 - **US-05 — Real-time feedback during export**
-    - **AC-05.1** — Given I start export, when processing is underway, then a progress or loading indicator remains visible until completion or failure.
-        - UI-005-Progress  
-        - IT-007-Errors  
-        - E2E-004-Errors  
-    - **AC-05.2** — Given the playlist is successfully created, when export completes, then the progress indicator shows completion and a success confirmation is displayed.
-        - E2E-001-Export  
-    - **AC-05.3** — Given an error prevents completion, when the process stops, then I see an error state with clear next steps such as retry.
-        - UI-005-Progress  
-        - IT-007-Errors  
-        - E2E-004-Errors  
+    - **AC-05.1** Progress shown  
+        - UI-005-Progress — Idle to loading to success or error  
+        - IT-007-Errors — Backend failure returns error contract  
+        - E2E-004-Errors — Progress shows error  
+    - **AC-05.2** Success state  
+        - E2E-001-Export — Happy path including auth  
+    - **AC-05.3** Error state  
+        - UI-005-Progress — Idle to loading to success or error  
+        - IT-007-Errors — Backend failure returns error contract  
+        - E2E-004-Errors — Progress shows error  
 
 - **US-06 — Error handling**
-    - **AC-06.1** — Given a song cannot be added to Spotify (for example, not found or region-restricted), when the export runs, then I see an error message identifying the issue and options to skip the song and continue or cancel the export.
-        - UT-005-Export  
-        - UI-006-Errors  
-        - IT-011-Errors  
-        - E2E-009-Errors  
-    - **AC-06.2** — Given Spotify rate limits are reached, when the export runs, then I see a “Try again later” message that explains the condition and suggests a retry.
-        - UT-005-Export  
-        - IT-008-Export  
-        - E2E-005-RateLimit  
-    - **AC-06.3** — Given one or more errors occur, when I choose how to proceed, then I can retry, skip all failing songs, or cancel the export.
-        - UT-007-Export  
-        - UI-006-Errors  
-        - IT-011-Errors  
-        - E2E-009-Errors  
+    - **AC-06.1** Per-song errors surfaced  
+        - UT-005-Export — 429 backoff policy  
+        - UI-006-Errors — List plus skip or retry actions  
+        - IT-011-Errors — Per-track 404 list  
+        - E2E-009-Errors — Partial failures  
+    - **AC-06.2** 429 shows try again later  
+        - UT-005-Export — 429 backoff policy  
+        - IT-008-Export — Inject 429 with retry guidance  
+        - E2E-005-RateLimit — 429 path  
+    - **AC-06.3** Retry or skip available  
+        - UT-007-Export — Per-item error surfacing  
+        - UI-006-Errors — List plus skip or retry actions  
+        - IT-011-Errors — Per-track 404 list  
+        - E2E-009-Errors — Partial failures  
 
 - **US-07 — Confirmation with playlist link**
-    - **AC-07.1** — Given export succeeds, when the flow completes, then I see a confirmation with a clickable link to the new Spotify playlist.
-        - UI-007-Confirm  
-        - IT-009-Confirm  
-    - **AC-07.2** — Given I click the confirmation link, when the Spotify app is installed, then the playlist opens in the app; otherwise, it opens in the browser with a web fallback.
-        - UI-008-DeepLink  
-        - E2E-006-DeepLink  
+    - **AC-07.1** Confirmation link present  
+        - UI-007-Confirm — Link present and correct  
+        - IT-009-Confirm — Response includes playlist URL  
+    - **AC-07.2** Deep link with fallback  
+        - UI-008-DeepLink — App deep link and web fallback  
+        - E2E-006-DeepLink — App versus web fallback  
 
 - **US-08 — Revoke Spotify access**
-    - **AC-08.1** — Given I am connected to Spotify, when I choose “Disconnect Spotify” in settings, then the integration is revoked and tokens are invalidated so protected Spotify calls are no longer possible.
-        - IT-010-Auth  
-        - E2E-007-Revoke  
-    - **AC-08.2** — Given I have revoked access, when I attempt to export again, then I am prompted to reconnect to Spotify.
-        - UI-001-AuthGuard  
-        - IT-010-Auth  
-        - E2E-007-Revoke  
-    - **AC-08.3** — Given I revoke access in Melodex, when I check my Spotify account’s connected apps, then Melodex no longer appears in the list of authorized applications (subject to Spotify’s propagation timing).
-        - IT-010-Auth  
+    - **AC-08.1** Disconnect invalidates tokens  
+        - UT-002-Auth — Revoke clears tokens  
+        - IT-010-Auth — Revoke requires reconnect to export  
+        - E2E-007-Revoke — Blocked until reconnect  
+    - **AC-08.2** Export prompts reconnect  
+        - UI-001-AuthGuard — Export CTA prompts connect when unauthenticated  
+        - IT-010-Auth — Revoke requires reconnect to export  
+        - E2E-007-Revoke — Blocked until reconnect  
+    - **AC-08.3** Removed from Spotify connected apps  
+        - IT-010-Auth — Revoke requires reconnect to export  
 
 ### Baseline Testing
 
 - **Baseline — Ranking flows & filters**
-    - **AC-F.1** — Given I adjust ranking filters, when I have not clicked Apply, then no background fetch occurs.
-        - UT-012-Ranking  
-    - **AC-F.2** — Given the app preloads or refreshes previews/data, when background fetching occurs, then the burst is capped at approximately 33 items to control cost and latency.
-        - UT-012-Ranking  
-    - **AC-F.3** — Given I apply filters, when the list updates, then UI elements are not clipped or truncated and remain navigable.
-        - UI-009-ExportModal  
+    - **AC-F.1** No auto-fetch until Apply  
+        - UT-012-Ranking — ELO math sanity  
+    - **AC-F.2** Background burst capped about 33  
+        - UT-012-Ranking — ELO math sanity  
+    - **AC-F.3** Filters do not clip UI  
+        - UI-009-ExportModal — Renders zero items confirm disabled  
 
 - **Baseline — Rankings playback stability**
-    - **AC-P.1** — Given a preview URL has expired, when I attempt playback, then the preview refreshes and playback resumes without manual reload.
-        - IT-012-Ranked  
-    - **AC-P.2** — Given I navigate or refresh the page, when previews are displayed, then no broken player states persist and controls remain responsive.
-        - IT-012-Ranked  
+    - **AC-P.1** Older previews refresh  
+        - IT-012-Ranked — Ranked endpoint contract  
+    - **AC-P.2** No broken players  
+        - IT-012-Ranked — Ranked endpoint contract  
 
 ---
 

--- a/melodex-back-end/controllers/AuthController.js
+++ b/melodex-back-end/controllers/AuthController.js
@@ -69,6 +69,17 @@ const AuthController = {
     try {
       const code = req.query.code;
       const state = req.query.state;
+      const err = req.query.error;
+
+      if (err === 'access_denied') {
+        // Clear temp cookies and bounce back to login with the error
+        res.setHeader('Set-Cookie', [
+          serializeCookie('oauth_state', '',   { maxAge: 0 }),
+          serializeCookie('pkce_verifier', '', { maxAge: 0 })
+        ]);
+        return res.redirect('/login?error=access_denied');
+      }
+
       if (!code || !state) return res.redirect('/login?error=missing_params');
 
       // 1) Read temp cookies (no cookie-parser needed)


### PR DESCRIPTION
### Story / AC
- **Story:** US-01 — Authenticate with Spotify
- **AC:**  
  - **AC-01.3** — Cancel at Spotify → no tokens stored; remain unauthenticated  
  - **AC-01.4** — Credentials stored only in secure httpOnly/SameSite cookies; never in web storage  
  - **AC-01.5** — On 401, attempt a single refresh + retry; otherwise logout/prompt reconnect

### Changes
- **Auth callback — cancel path**
  - Handle `GET /auth/callback?error=access_denied&state=...` explicitly.
  - Ensure **no `access`/`refresh` cookies** are set; clear temp cookies (`oauth_state`, `pkce_verifier`) and **redirect to `/login?error=access_denied`**.
- **Secure storage assertion (frontend)**
  - Add a small unit check ensuring **no writes to `localStorage`/`sessionStorage`** for tokens (defensive proof for AC-01.4).
- **Single-refresh logic (frontend helper)**
  - Extend the auth fetch wrapper to **attempt one `/auth/refresh`** on a `401` from a protected call, **retry once**, then fall back to logout/prompt.
- **(Tiny backend stub for refresh)**
  - Expose **`POST /auth/refresh`** that issues a new short-lived `access` cookie **iff** a valid `refresh` cookie is present; otherwise `401`.
  - Note: endpoint is minimal and keeps tokens in **httpOnly** cookies only.

### Tests
- **IT-001d-Auth (AC-01.3):** `/auth/callback?error=access_denied&state=xyz`  
  - Asserts redirect to `/login?error=access_denied`  
  - **No `access`/`refresh` cookies** set; temp cookies cleared
- **UT-008-Auth (AC-01.5):** single refresh on `401`  
  - 401 → calls `/auth/refresh` once → retries original request  
  - If refresh fails → emits “logout/prompt reconnect”
- **UI/Unit — No web storage writes (AC-01.4):**  
  - Asserts **no `localStorage`/`sessionStorage`** keys like `access`/`refresh` are ever written

### Risks / Rollback
- **Low risk**: cancel path is additive and cookie-only; refresh stub is isolated.  
- **Rollback:** remove `/auth/refresh` route and the single-refresh code path; keep prior behavior (prompt on 401).  
- **Security:** tokens remain **httpOnly/SameSite/Secure** cookies; tests enforce **no web-storage** usage.
